### PR TITLE
Strongly typed OPA experiments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 package-lock.json
 
 a.out
+core

--- a/scripts/ir2cpp_after.cc
+++ b/scripts/ir2cpp_after.cc
@@ -4,6 +4,15 @@ int main() {
   PopulatePolicy(policy);
   policy_singleton = &policy;
 
+  // TODO(dkorolev): This would only work for strings that are valid C++ identifiers, of course.
+  for (std::string const& s : policy.strings) {
+    std::cout << "struct rego_string_" << s << " final{constexpr static char const* s = \"" << s
+              << "\"; template <class T> static decltype(std::declval<T>()." << s
+              << ") GetValueByKeyFrom(T&& x) { return std::forward<T>(x)." << s
+              << "; } static OPAValue GetValueByKeyFrom(OPAValue const& object) { return object.DoGetValueByKey(\"" << s
+              << "\");}};";
+  }
+
   for (size_t i = 0; i < policy.function_bodies.size(); ++i) {
     Output output(std::cout, Output::ForFunction(), i, policy.functions[i]);
     policy.function_bodies[i](policy).output(output);

--- a/scripts/ir2cpp_after.cc
+++ b/scripts/ir2cpp_after.cc
@@ -7,6 +7,9 @@ int main() {
   for (size_t i = 0; i < policy.function_bodies.size(); ++i) {
     std::cout << "// function " << i << ":\n";
     Locals locals;
+    for (size_t j = 0u; j < policy.functions[i].size(); ++j) {
+      locals[OPALocalWrapper(policy.functions[i][j])].MarkAsFunctionArgument();
+    }
     policy.function_bodies[i](policy).analyze(
         locals,
         [&locals]() { std::cout << locals << locals << std::endl; },
@@ -18,6 +21,8 @@ int main() {
 
   {
     Locals locals;
+    locals[OPALocalWrapper(0)].MarkAsFunctionArgument();
+    locals[OPALocalWrapper(1)].MarkAsFunctionArgument();
     policy.plans["main"](policy).analyze(
         locals,
         [&locals]() { std::cout << locals << locals << std::endl; },

--- a/scripts/ir2cpp_after.cc
+++ b/scripts/ir2cpp_after.cc
@@ -16,12 +16,12 @@ int main() {
       std::cout << "locals[" << policy.functions[i][j] << "] = p" << j + 1u << ";\n";
     }
     std::cout << "value_t retval; \n";
-    policy.function_bodies[i](policy)([]() {});
+    policy.function_bodies[i](policy).dump([]() {});
     std::cout << "return retval; }\n";
   }
 
   std::cout << "result_set_t policy(value_t input, value_t data) {\n";
   std::cout << "locals_t locals; locals[0] = input; locals[1] = data; result_set_t result;\n";
-  policy.plans["main"](policy)([]() {});
+  policy.plans["main"](policy).dump([]() {});
   std::cout << "return result; }\n";
 }

--- a/scripts/ir2cpp_after.cc
+++ b/scripts/ir2cpp_after.cc
@@ -4,6 +4,18 @@ int main() {
   policy_singleton = &policy;
 
 #if 0
+  for (size_t i = 0; i < policy.function_bodies.size(); ++i) {
+    std::cout << "// function " << i << ":\n";
+    Locals locals;
+    policy.function_bodies[i](policy).analyze(
+        locals,
+        [&locals]() { std::cout << locals << locals << std::endl; },
+        [&locals]() {
+          std::cout << "// DONE?\n" << locals << std::endl;
+          throw std::logic_error("Internal invariant failed.");
+        });
+  }
+
   {
     Locals locals;
     policy.plans["main"](policy).analyze(

--- a/scripts/ir2cpp_after.cc
+++ b/scripts/ir2cpp_after.cc
@@ -3,6 +3,19 @@ int main() {
   PopulatePolicy(policy);
   policy_singleton = &policy;
 
+#if 0
+  {
+    Locals locals;
+    policy.plans["main"](policy).analyze(
+        locals,
+        [&locals]() { std::cout << locals << locals << std::endl; },
+        [&locals]() {
+          std::cout << "// DONE?\n" << locals << std::endl;
+          throw std::logic_error("Internal invariant failed.");
+        });
+  }
+#endif
+
   for (size_t i = 0; i < policy.function_bodies.size(); ++i) {
     std::cout << "value_t function_" << i << "(";
     for (size_t j = 0u; j < policy.functions[i].size(); ++j) {

--- a/scripts/ir2cpp_after.cc
+++ b/scripts/ir2cpp_after.cc
@@ -3,55 +3,6 @@ int main() {
   PopulatePolicy(policy);
   policy_singleton = &policy;
 
-#if 0
-  for (size_t i = 0; i < policy.function_bodies.size(); ++i) {
-    std::cout << "// function " << i << ":\n";
-    Locals locals;
-    for (size_t j = 0u; j < policy.functions[i].size(); ++j) {
-      locals[OPALocalWrapper(policy.functions[i][j])].MarkAsFunctionArgument();
-    }
-    policy.function_bodies[i](policy).analyze(
-        locals,
-        [&locals]() { std::cout << locals << locals << std::endl; },
-        [&locals]() {
-          std::cout << "// DONE?\n" << locals << std::endl;
-          throw std::logic_error("Internal invariant failed.");
-        });
-  }
-
-  {
-    Locals locals;
-    locals[OPALocalWrapper(0)].MarkAsFunctionArgument();
-    locals[OPALocalWrapper(1)].MarkAsFunctionArgument();
-    policy.plans["main"](policy).analyze(
-        locals,
-        [&locals]() { std::cout << locals << locals << std::endl; },
-        [&locals]() {
-          std::cout << "// DONE?\n" << locals << std::endl;
-          throw std::logic_error("Internal invariant failed.");
-        });
-  }
-#endif
-
-#if 0
-  for (size_t i = 0; i < policy.function_bodies.size(); ++i) {
-    std::cout << "value_t function_" << i << "(";
-    for (size_t j = 0u; j < policy.functions[i].size(); ++j) {
-      if (j) {
-        std::cout << ", ";
-      }
-      std::cout << "value_t p" << j + 1u;
-    }
-    std::cout << ") { locals_t locals; ";
-    for (size_t j = 0u; j < policy.functions[i].size(); ++j) {
-      std::cout << "locals[" << policy.functions[i][j] << "] = p" << j + 1u << ";\n";
-    }
-    std::cout << "value_t retval; \n";
-    policy.function_bodies[i](policy).dump([]() {});
-    std::cout << "return retval; }\n";
-  }
-#endif
-
   for (size_t i = 0; i < policy.function_bodies.size(); ++i) {
     Output output(std::cout, Output::ForFunction(), i, policy.functions[i]);
     policy.function_bodies[i](policy).output(output);
@@ -61,11 +12,4 @@ int main() {
     Output output(std::cout, Output::ForPlan());
     policy.plans["main"](policy).output(output);
   }
-
-  /*
-  std::cout << "result_set_t policy(value_t input, value_t data) {\n";
-  std::cout << "locals_t locals; locals[0] = input; locals[1] = data; result_set_t result;\n";
-  policy.plans["main"](policy).dump([]() {});
-  std::cout << "return result; }\n";
-  */
 }

--- a/scripts/ir2cpp_after.cc
+++ b/scripts/ir2cpp_after.cc
@@ -1,3 +1,4 @@
+
 int main() {
   Policy policy;
   PopulatePolicy(policy);

--- a/scripts/ir2cpp_after.cc
+++ b/scripts/ir2cpp_after.cc
@@ -33,6 +33,7 @@ int main() {
   }
 #endif
 
+#if 0
   for (size_t i = 0; i < policy.function_bodies.size(); ++i) {
     std::cout << "value_t function_" << i << "(";
     for (size_t j = 0u; j < policy.functions[i].size(); ++j) {
@@ -49,9 +50,22 @@ int main() {
     policy.function_bodies[i](policy).dump([]() {});
     std::cout << "return retval; }\n";
   }
+#endif
 
+  for (size_t i = 0; i < policy.function_bodies.size(); ++i) {
+    Output output(std::cout, Output::ForFunction(), i, policy.functions[i]);
+    policy.function_bodies[i](policy).output(output);
+  }
+
+  {
+    Output output(std::cout, Output::ForPlan());
+    policy.plans["main"](policy).output(output);
+  }
+
+  /*
   std::cout << "result_set_t policy(value_t input, value_t data) {\n";
   std::cout << "locals_t locals; locals[0] = input; locals[1] = data; result_set_t result;\n";
   policy.plans["main"](policy).dump([]() {});
   std::cout << "return result; }\n";
+  */
 }

--- a/scripts/ir2cpp_before.cc
+++ b/scripts/ir2cpp_before.cc
@@ -430,7 +430,7 @@ struct Output final {
 
   ~Output() {
     for (OPALocalWrapper i : vars.all_declarations) {
-      os << vars[i].type << ' ' << vars[i].name << ';' << " // Index: " << i.local << '\n';
+      os << vars[i].type << ' ' << vars[i].name << ';';
     }
     root.TopDownPrint(os);
     os << at_end;

--- a/scripts/ir2cpp_before.cc
+++ b/scripts/ir2cpp_before.cc
@@ -71,6 +71,11 @@ struct LocalValue final {
     return x;
   }
 
+  static LocalValue const& StaticUndefined() {
+    static LocalValue undefined;
+    return undefined;
+  }
+
   void ResetToUndefined(callback_t next) {
     LocalType const save_type = type;
     type = LocalType::Undefined;
@@ -126,15 +131,15 @@ struct LocalValue final {
     type = save_type;
   }
 
-  LocalValue& GetByKey(char const* key) {
+  LocalValue const& GetByKey(char const* key) {
     if (type != LocalType::Object) {
       // TODO(dkorolev): Message type, `file:row:col`.
-      throw std::logic_error("Internal invariant failed.");
+      return StaticUndefined();
     }
     auto const cit = object_keys.find(key);
     if (cit == object_keys.end()) {
       // TODO(dkorolev): Message type, `file:row:col`.
-      throw std::logic_error("Internal invariant failed.");
+      return StaticUndefined();
     }
     return cit->second;
   }
@@ -203,8 +208,9 @@ struct Locals final {
   }
 
   void SetReturnValue(LocalValue const& value, callback_t next) {
-    if (return_value.type != LocalType::Undefined) {
-      throw std::logic_error("Internal invariant failed.");
+    if (return_value.type == LocalType::Undefined) {
+      // TODO(dkorolev): Implement this.
+      return;
     }
     return_value = value;
     next();

--- a/scripts/ir2cpp_before.cc
+++ b/scripts/ir2cpp_before.cc
@@ -50,11 +50,68 @@ struct OPABoolean final {
 
 using callback_t = std::function<void()>;
 
+enum class LocalType : uint8_t { Undefined = 0, Null = 1, String = 2, Number = 3, Boolean = 4, Array = 5, Object = 6 };
+
+struct LocalValue final {
+  LocalType type = LocalType::Undefined;
+  std::map<std::string, LocalValue> object_keys;
+
+  void ResetToUndefined() { type = LocalType::Undefined; }
+  void MakeNull() { type = LocalType::Null; }
+  void SetNumber() { type = LocalType::Number; }
+  void MakeObject() { type = LocalType::Object; }
+  bool IsUndefined() const { return type == LocalType::Undefined; }
+
+  LocalValue& operator=(LocalValue const& rhs) {
+    type = rhs.type;
+    return *this;
+  }
+  LocalValue& operator=(char const*) {
+    type = LocalType::String;
+    return *this;
+  }
+  LocalValue& operator=(OPABoolean) {
+    type = LocalType::Boolean;
+    return *this;
+  }
+
+  LocalValue& GetByKey(char const* key) {
+    if (type != LocalType::Object) {
+      // TODO(dkorolev): Message type, `file:row:col`.
+      throw std::logic_error("Internal invariant failed.");
+    }
+    auto const cit = object_keys.find(key);
+    if (cit == object_keys.end()) {
+      // TODO(dkorolev): Message type, `file:row:col`.
+      throw std::logic_error("Internal invariant failed.");
+    }
+    return cit->second;
+  }
+
+  void SetValueForKey(char const* key, LocalValue const& value) { object_keys[key] = value; }
+};
+
+struct Locals final {
+  std::map<size_t, LocalValue> values;
+  LocalValue return_value;
+
+  LocalValue& operator[](OPALocalWrapper local) { return values[local.local]; }
+
+  void AddToResultsSet(LocalValue const&) {
+    // TODO(dkorolev): Implement this.
+    // TODO(dkorolev): Can only use `AddToResultsSet` from plans, not from functions, right?
+  }
+
+  void SetReturnValue(LocalValue const& value) { return_value = value; }
+};
+
 struct IRStatement final {
+  std::function<void(Locals&, callback_t next, callback_t done)> analyze;
   std::function<void(callback_t)> dump;
-  IRStatement(std::function<void(callback_t)> dump) : dump(dump) {}
+  IRStatement(std::function<void(Locals&, callback_t, callback_t)> analyze, std::function<void(callback_t)> dump)
+      : analyze(analyze), dump(dump) {}
   static IRStatement Dummy() {
-    return IRStatement([](callback_t next) { next(); });
+    return IRStatement([](Locals&, callback_t, callback_t) {}, [](callback_t next) { next(); });
   }
 };
 
@@ -70,128 +127,218 @@ struct Policy final {
 inline static Policy* policy_singleton;
 
 IRStatement stmtAssignVarOnce(OPALocalWrapper source, OPALocalWrapper target) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "if (locals[" << target.local << "].IsUndefined()) { locals[" << target.local << "] = locals["
-              << source.local << "];\n";
-    next();
-    std::cout << "}\n";
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        locals[target] = locals[source];
+        next();
+      },
+      [=](callback_t next) {
+        std::cout << "if (locals[" << target.local << "].IsUndefined()) { locals[" << target.local << "] = locals["
+                  << source.local << "];\n";
+        next();
+        std::cout << "}\n";
+      });
 }
 
 IRStatement stmtAssignVarOnce(const char* source, OPALocalWrapper target) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "if (locals[" << target.local << "].IsUndefined()) { locals[" << target.local << "].SetString(\""
-              << source << "\");\n";
-    next();
-    std::cout << "}\n";
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        if (locals[target].IsUndefined()) {
+          // TODO(dkorolev): Or is such a failure "breaking" the block?
+          locals[target] = source;
+        }
+        next();
+      },
+      [=](callback_t next) {
+        std::cout << "if (locals[" << target.local << "].IsUndefined()) { locals[" << target.local << "].SetString(\""
+                  << source << "\");\n";
+        next();
+        std::cout << "}\n";
+      });
 }
 
 IRStatement stmtAssignVarOnce(OPABoolean source, OPALocalWrapper target) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "if (locals[" << target.local << "].IsUndefined()) { locals[" << target.local << "].SetBoolean("
-              << std::boolalpha << source.boolean << ");\n";
-    next();
-    std::cout << "}\n";
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        if (locals[target].IsUndefined()) {
+          locals[target] = source;
+        }
+        next();
+      },
+      [=](callback_t next) {
+        std::cout << "if (locals[" << target.local << "].IsUndefined()) { locals[" << target.local << "].SetBoolean("
+                  << std::boolalpha << source.boolean << ");\n";
+        next();
+        std::cout << "}\n";
+      });
 }
 
 IRStatement stmtAssignVar(OPALocalWrapper source, OPALocalWrapper target) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "locals[" << target.local << "] = locals[" << source.local << "];\n";
-    next();
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        locals[target] = locals[source];
+        next();
+      },
+      [=](callback_t next) {
+        std::cout << "locals[" << target.local << "] = locals[" << source.local << "];\n";
+        next();
+      });
 }
 
 IRStatement stmtDot(OPALocalWrapper source, char const* key, OPALocalWrapper target) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "locals[" << target.local << "] = locals[" << source.local << "].GetByKey(\"" << key << "\");";
-    next();
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        locals[target] = locals[source].GetByKey(key);
+        next();
+      },
+      [=](callback_t next) {
+        std::cout << "locals[" << target.local << "] = locals[" << source.local << "].GetByKey(\"" << key << "\");";
+        next();
+      });
 }
 
 IRStatement stmtEqual(OPALocalWrapper a, const char* b) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "if (locals[" << a.local << "].IsString(\"" << b << "\")) {\n";
-    next();
-    std::cout << "}\n";
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t done) {
+        next();
+        done();
+      },
+      [=](callback_t next) {
+        std::cout << "if (locals[" << a.local << "].IsString(\"" << b << "\")) {\n";
+        next();
+        std::cout << "}\n";
+      });
 }
 
 IRStatement stmtIsDefined(OPALocalWrapper source) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "if (!locals[" << source.local << "].IsUndefined()) {\n";
-    next();
-    std::cout << "}\n";
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t done) {
+        if (locals[source].IsUndefined()) {
+          next();
+        } else {
+          done();
+        }
+      },
+      [=](callback_t next) {
+        std::cout << "if (!locals[" << source.local << "].IsUndefined()) {\n";
+        next();
+        std::cout << "}\n";
+      });
 }
 
 IRStatement stmtIsUndefined(OPALocalWrapper source) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "if (locals[" << source.local << "].IsUndefined()) {\n";
-    next();
-    std::cout << "}\n";
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t done) {
+        if (!locals[source].IsUndefined()) {
+          next();
+        } else {
+          done();
+        }
+      },
+      [=](callback_t next) {
+        std::cout << "if (locals[" << source.local << "].IsUndefined()) {\n";
+        next();
+        std::cout << "}\n";
+      });
 }
 
 IRStatement stmtMakeNull(OPALocalWrapper target) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "locals[" << target.local << "].MakeNull();\n";
-    next();
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        locals[target].MakeNull();
+        next();
+      },
+      [=](callback_t next) {
+        std::cout << "locals[" << target.local << "].MakeNull();\n";
+        next();
+      });
 }
 
 IRStatement stmtMakeNumberRef(OPAStringConstant value, OPALocalWrapper target) {
-  return IRStatement([=](callback_t next) {
-    Policy const& policy = *policy_singleton;
-    // TODO: Not `FromString`, of course.
-    std::cout << "locals[" << target.local << "].SetNumberFromString(\"" << policy.strings[value.string_index]
-              << "\");\n";
-    next();
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        locals[target].SetNumber();
+        next();
+      },
+      [=](callback_t next) {
+        Policy const& policy = *policy_singleton;
+        // TODO: Not `FromString`, of course.
+        std::cout << "locals[" << target.local << "].SetNumberFromString(\"" << policy.strings[value.string_index]
+                  << "\");\n";
+        next();
+      });
 }
 
 IRStatement stmtMakeObject(OPALocalWrapper target) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "locals[" << target.local << "].MakeObject();\n";
-    next();
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        locals[target].MakeObject();
+        next();
+      },
+      [=](callback_t next) {
+        std::cout << "locals[" << target.local << "].MakeObject();\n";
+        next();
+      });
 }
 
+// NOTE(dkorolev): This is a static, `constexpr`, "compile-time" check. It should not generate any output code.
 IRStatement stmtNotEqual(OPABoolean a, OPABoolean b) {
   if (a.boolean != b.boolean) {
-    return IRStatement([=](callback_t next) { next(); });
+    return IRStatement([=](Locals&, callback_t next, callback_t) { next(); }, [=](callback_t next) { next(); });
   } else {
-    return IRStatement::Dummy();
+    return IRStatement([=](Locals&, callback_t, callback_t done) { done(); }, [=](callback_t) {});
   }
 }
 
 IRStatement stmtObjectInsert(char const* key, OPALocalWrapper value, OPALocalWrapper object) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "locals[" << object.local << "].SetValueForKey(\"" << key << "\", locals[" << value.local << "]);\n";
-    next();
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        locals[object].SetValueForKey(key, locals[value]);
+        next();
+      },
+      [=](callback_t next) {
+        std::cout << "locals[" << object.local << "].SetValueForKey(\"" << key << "\", locals[" << value.local
+                  << "]);\n";
+        next();
+      });
 }
 
 IRStatement stmtResetLocal(OPALocalWrapper target) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "locals[" << target.local << "].ResetToUndefined();\n";
-    next();
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        locals[target].ResetToUndefined();
+        next();
+      },
+      [=](callback_t next) {
+        std::cout << "locals[" << target.local << "].ResetToUndefined();\n";
+        next();
+      });
 }
 
 IRStatement stmtResultSetAdd(OPALocalWrapper value) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "result.AddToResultSet(locals[" << value.local << "]);\n";
-    next();
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        locals.AddToResultsSet(locals[value]);
+        next();
+      },
+      [=](callback_t next) {
+        std::cout << "result.AddToResultSet(locals[" << value.local << "]);\n";
+        next();
+      });
 }
 
 IRStatement stmtReturnLocalStmt(OPALocalWrapper source) {
-  return IRStatement([=](callback_t next) {
-    std::cout << "retval = locals[" << source.local << "];\n";
-    next();
-  });
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        // TODO(dkorolev): Ask the OPA folks whether this should "return" or just save the return value. And is there
+        // redundancy.
+        locals.SetReturnValue(locals[source]);
+        next();
+      },
+      [=](callback_t next) {
+        std::cout << "retval = locals[" << source.local << "];\n";
+        next();
+      });
 }
 
 IRStatement stmtCall(OPAUserDefinedFunction f, std::vector<OPALocalWrapper> const& args, OPALocalWrapper target) {
@@ -200,18 +347,22 @@ IRStatement stmtCall(OPAUserDefinedFunction f, std::vector<OPALocalWrapper> cons
     throw std::logic_error("Internal invariant failed.");
   }
 
-  return IRStatement([=](callback_t next) {
-    std::cout << "locals[" << target.local << "] = function_" << f.function << "(";
-    for (size_t i = 0u; i < args.size(); ++i) {
-      if (i) {
-        std::cout << ", ";
-      }
-      std::cout << "locals[" << args[i].local << "]";
-    }
-    std::cout << ");\n";
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        // TODO(dkorolev): Implement this.
+      },
+      [=](callback_t next) {
+        std::cout << "locals[" << target.local << "] = function_" << f.function << "(";
+        for (size_t i = 0u; i < args.size(); ++i) {
+          if (i) {
+            std::cout << ", ";
+          }
+          std::cout << "locals[" << args[i].local << "]";
+        }
+        std::cout << ");\n";
 
-    next();
-  });
+        next();
+      });
 }
 
 IRStatement stmtCall(OPABuiltin f, std::vector<OPALocalWrapper> const& args, OPALocalWrapper target) {
@@ -220,35 +371,43 @@ IRStatement stmtCall(OPABuiltin f, std::vector<OPALocalWrapper> const& args, OPA
   }
 
   // TODO: Fix this copy-paste in `stmtCall`.
-  return IRStatement([=](callback_t next) {
-    std::cout << "locals[" << target.local << "] = " << f.builtin_name << "(";
-    for (size_t i = 0u; i < f.args_count; ++i) {
-      if (i) {
-        std::cout << ", ";
-      }
-      std::cout << "locals[" << args[i].local << "]";
-    }
-    std::cout << ");\n";
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t) {
+        // TODO(dkorolev): Implement this.
+      },
+      [=](callback_t next) {
+        std::cout << "locals[" << target.local << "] = " << f.builtin_name << "(";
+        for (size_t i = 0u; i < f.args_count; ++i) {
+          if (i) {
+            std::cout << ", ";
+          }
+          std::cout << "locals[" << args[i].local << "]";
+        }
+        std::cout << ");\n";
 
-    next();
-  });
+        next();
+      });
 }
 
 IRStatement stmtBlock(std::vector<IRStatement> const& code) {
-  return IRStatement([code](callback_t done) {
-    if (!code.empty()) {
-      size_t i = 0u;
+  return IRStatement(
+      [=](Locals& locals, callback_t next, callback_t done) {
+        // TODO(dkorolev): Implement this.
+      },
+      [=](callback_t next) {
+        if (!code.empty()) {
+          size_t i = 0u;
 
-      callback_t next = [&]() {
-        if (i < code.size()) {
-          size_t const save = i;
-          ++i;
-          code[save].dump(next);
+          callback_t inner_next = [&]() {
+            if (i < code.size()) {
+              size_t const save = i;
+              ++i;
+              code[save].dump(inner_next);
+            }
+          };
+
+          inner_next();
         }
-      };
-
-      next();
-    }
-    done();
-  });
+        next();
+      });
 }

--- a/scripts/ir2cpp_before.cc
+++ b/scripts/ir2cpp_before.cc
@@ -495,7 +495,7 @@ struct Output final {
 
   void Dot(OPALocalWrapper target, OPALocalWrapper source, char const* key) {
     std::ostringstream os;
-    os << "GetValueByKey(" << current->Materialize(source) << ",\"" << key << "\")";
+    os << "rego_string_" << key << "::GetValueByKeyFrom(" << current->Materialize(source) << ')';
     current->DoAssignVar(target, os.str(), "decltype(" + os.str() + ')');
   }
 

--- a/scripts/ir2cpp_runner_after.cc
+++ b/scripts/ir2cpp_runner_after.cc
@@ -1,3 +1,4 @@
+
 int main() {
   std::string test_input;
   JSONValue test_data_that_is_empty = JSONObject();

--- a/scripts/ir2cpp_runner_before.cc
+++ b/scripts/ir2cpp_runner_before.cc
@@ -7,95 +7,121 @@
 
 using namespace current::json;
 
-struct value_t final {
+using OPAString = Optional<std::string>;
+using OPANumber = Optional<double>;
+using OPABoolean = Optional<bool>;
+
+class OPAValue final {
+  // TODO(dkorolev): Make it `private`, once the builtins are cleaned up.
+ public:
   JSONValue opa_value;  // TODO: OPA's `undefined` is not the same as `null`, of course.
 
-  value_t() : opa_value(JSONNull()) {}
-  value_t(JSONValue opa_value) : opa_value(std::move(opa_value)) {}
+ public:
+  OPAValue() : opa_value(JSONNull()) {}
+  OPAValue(JSONValue opa_value) : opa_value(std::move(opa_value)) {}
+  OPAValue(OPAString const& s) {
+    if (Exists(s)) {
+      opa_value = JSONString(Value(s));
+    }
+  }
+  OPAValue(OPANumber const& v) {
+    if (Exists(v)) {
+      opa_value = JSONNumber(Value(v));
+    }
+  }
+  OPAValue(OPABoolean const& b) {
+    if (Exists(b)) {
+      opa_value = JSONBoolean(Value(b));
+    }
+  }
 
-  void ResetToUndefined() { opa_value = JSONNull(); }
+  void DoResetToUndefined() { opa_value = JSONNull(); }
+  bool DoIsUndefined() const { return Exists<JSONNull>(opa_value); }
 
-  bool IsUndefined() const { return Exists<JSONNull>(opa_value); }
-
-  bool IsString(char const* desired) const {
+  bool DoIsStringEqualTo(char const* desired) const {
     return Exists<JSONString>(opa_value) && Value<JSONString>(opa_value).string == desired;
   }
 
-  void MakeObject() { opa_value = JSONObject(); }
+  void DoMakeObject() { opa_value = JSONObject(); }
 
-  void MakeNull() {
-    opa_value = JSONNull();  // TODO: See above.
+  void DoMakeNull() {
+    opa_value = JSONNull();  // TODO: See above re. `null` vs. `undefined`.
   }
 
-  void SetBoolean(bool value) { opa_value = JSONBoolean(value); }
-
-  void SetString(char const* value) { opa_value = JSONString(value); }
-
-  void SetNumberFromString(char const* value) { opa_value = JSONNumber(current::FromString<double>(value)); }
-
-  value_t GetByKey(char const* key) {
-    return Exists<JSONObject>(opa_value) ? Value<JSONObject>(opa_value)[key] : value_t();
+  OPAValue DoGetValueByKey(char const* key) const {
+    return Exists<JSONObject>(opa_value) ? Value<JSONObject>(opa_value)[key] : OPAValue();
   }
 
-  void SetValueForKey(char const* key, value_t const& value) {
+  void DoSetValueForKey(char const* key, OPAValue const& value) {
     if (Exists<JSONObject>(opa_value)) {
       Value<JSONObject>(opa_value).push_back(key, value.opa_value);
     }
   }
 };
 
-inline value_t ResetToUndefined() { return value_t(); }
-inline value_t MakeNull() {
-  value_t res;
-  res.MakeNull();
-  return res;
+inline void ResetToUndefined(OPAValue& value) { value.DoResetToUndefined(); }
+inline void ResetToUndefined(Optional<std::string>& value) { value = nullptr; }
+
+inline void MakeNull(OPAValue& value) { value.DoMakeNull(); }
+inline void MakeObject(OPAValue& value) { value.DoMakeObject(); }
+
+inline bool IsUndefined(OPAValue const& value) { return value.DoIsUndefined(); }
+inline bool IsUndefined(Optional<std::string> const& value) { return Exists(value); }
+
+inline bool IsStringEqualTo(OPAValue const& value, char const* s) { return value.DoIsStringEqualTo(s); }
+
+inline bool IsStringEqualTo(OPAString const& value, char const* s) { return Exists(value) && Value(value) == s; }
+
+// TODO(dkorolev): Should return a custom type that can be assigned to a string "variable" too!
+inline OPAValue Undefined() {
+  OPAValue undefined;
+  return undefined;
 }
-inline value_t MakeObject() {
-  value_t res;
-  res.MakeObject();
-  return res;
+inline OPAValue Object() {
+  OPAValue object;
+  object.DoMakeObject();
+  return object;
 }
-inline value_t SetString(char const* s) {
-  value_t res;
-  res.SetString(s);
-  return res;
-}
-inline value_t SetBoolean(bool b) {
-  value_t res;
-  res.SetBoolean(b);
-  return res;
-}
-inline value_t SetNumberFromString(char const* s) {
-  value_t res;
-  res.SetNumberFromString(s);
-  return res;
+inline JSONValue Null() {
+  static JSONValue null = JSONNull();  // TODO(dkorolev): This `null` is the same as `undefined`.
+  return null;
 }
 
-inline value_t opa_plus(value_t const& a, value_t const& b) {
+// TODO(dkorolev): Use a proper `template` for user-defined types here.
+inline OPAValue GetValueByKey(OPAValue const& object, char const* key) { return object.DoGetValueByKey(key); }
+
+inline void SetValueForKey(OPAValue& target, char const* key, OPAValue const& value) {
+  target.DoSetValueForKey(key, value);
+}
+
+inline OPANumber NumberFromString(char const* s) { return OPANumber(current::FromString<double>(s)); }
+
+inline OPAValue opa_plus(OPAValue const& a, OPAValue const& b) {
   if (Exists<JSONNumber>(a.opa_value) && Exists<JSONNumber>(b.opa_value)) {
-    return value_t(JSONNumber(Value<JSONNumber>(a.opa_value).number + Value<JSONNumber>(b.opa_value).number));
+    return OPAValue(JSONNumber(Value<JSONNumber>(a.opa_value).number + Value<JSONNumber>(b.opa_value).number));
   } else {
-    return value_t();
+    return OPAValue();
   }
 }
 
-inline value_t opa_minus(value_t const& a, value_t const& b) {
+inline OPAValue opa_minus(OPAValue const& a, OPAValue const& b) {
+  // TODO(dkorolev): Only work on numbers!
   if (Exists<JSONNumber>(a.opa_value) && Exists<JSONNumber>(b.opa_value)) {
-    return value_t(JSONNumber(Value<JSONNumber>(a.opa_value).number - Value<JSONNumber>(b.opa_value).number));
+    return OPAValue(JSONNumber(Value<JSONNumber>(a.opa_value).number - Value<JSONNumber>(b.opa_value).number));
   } else {
-    return value_t();
+    return OPAValue();
   }
 }
 
-inline value_t opa_mul(value_t const& a, value_t const& b) {
+inline OPAValue opa_mul(OPAValue const& a, OPAValue const& b) {
   if (Exists<JSONNumber>(a.opa_value) && Exists<JSONNumber>(b.opa_value)) {
-    return value_t(JSONNumber(Value<JSONNumber>(a.opa_value).number * Value<JSONNumber>(b.opa_value).number));
+    return OPAValue(JSONNumber(Value<JSONNumber>(a.opa_value).number * Value<JSONNumber>(b.opa_value).number));
   } else {
-    return value_t();
+    return OPAValue();
   }
 }
 
-inline value_t opa_range(value_t const& a, value_t const& b) {
+inline OPAValue opa_range(OPAValue const& a, OPAValue const& b) {
   if (Exists<JSONNumber>(a.opa_value) && Exists<JSONNumber>(b.opa_value)) {
     JSONArray array;
     int const va = static_cast<int>(Value<JSONNumber>(a.opa_value).number);
@@ -103,15 +129,15 @@ inline value_t opa_range(value_t const& a, value_t const& b) {
     for (int i = va; i <= vb; ++i) {
       array.push_back(JSONNumber(i));
     }
-    return value_t(array);
+    return OPAValue(array);
   } else {
-    return value_t();
+    return OPAValue();
   }
 }
 
-struct result_set_t final {
-  std::vector<value_t> result_set;
-  void AddToResultSet(value_t value) { result_set.push_back(std::move(value)); }
+struct OPAResult final {
+  std::vector<OPAValue> result_set;
+  void AddToResultSet(OPAValue value) { result_set.push_back(std::move(value)); }
   JSONValue pack() const {
     if (result_set.empty()) {
       return JSONNull();
@@ -124,7 +150,7 @@ struct result_set_t final {
       }
     } else {
       JSONArray array;
-      for (value_t const& value : result_set) {
+      for (OPAValue const& value : result_set) {
         JSONValue const& v = value.opa_value;
         if (Exists<JSONObject>(v)) {
           array.push_back(Value<JSONObject>(v)["result"]);

--- a/scripts/ir2cpp_runner_before.cc
+++ b/scripts/ir2cpp_runner_before.cc
@@ -44,6 +44,33 @@ struct value_t final {
   }
 };
 
+inline value_t ResetToUndefined() { return value_t(); }
+inline value_t MakeNull() {
+  value_t res;
+  res.MakeNull();
+  return res;
+}
+inline value_t MakeObject() {
+  value_t res;
+  res.MakeObject();
+  return res;
+}
+inline value_t SetString(char const* s) {
+  value_t res;
+  res.SetString(s);
+  return res;
+}
+inline value_t SetBoolean(bool b) {
+  value_t res;
+  res.SetBoolean(b);
+  return res;
+}
+inline value_t SetNumberFromString(char const* s) {
+  value_t res;
+  res.SetNumberFromString(s);
+  return res;
+}
+
 inline value_t opa_plus(value_t const& a, value_t const& b) {
   if (Exists<JSONNumber>(a.opa_value) && Exists<JSONNumber>(b.opa_value)) {
     return value_t(JSONNumber(Value<JSONNumber>(a.opa_value).number + Value<JSONNumber>(b.opa_value).number));

--- a/scripts/ir2cpp_runner_before.cc
+++ b/scripts/ir2cpp_runner_before.cc
@@ -1,6 +1,6 @@
+#include <cstdarg>
 #include <iostream>
 #include <map>
-#include <cstdarg>
 
 // TODO: Not a relative path, of course.
 #include "../current/blocks/json/json.h"
@@ -13,37 +13,25 @@ struct value_t final {
   value_t() : opa_value(JSONNull()) {}
   value_t(JSONValue opa_value) : opa_value(std::move(opa_value)) {}
 
-  void ResetToUndefined() {
-    opa_value = JSONNull();
-  }
+  void ResetToUndefined() { opa_value = JSONNull(); }
 
-  bool IsUndefined() const {
-    return Exists<JSONNull>(opa_value);
-  }
+  bool IsUndefined() const { return Exists<JSONNull>(opa_value); }
 
   bool IsString(char const* desired) const {
     return Exists<JSONString>(opa_value) && Value<JSONString>(opa_value).string == desired;
   }
 
-  void MakeObject() {
-    opa_value = JSONObject();
-  }
+  void MakeObject() { opa_value = JSONObject(); }
 
   void MakeNull() {
     opa_value = JSONNull();  // TODO: See above.
   }
 
-  void SetBoolean(bool value) {
-    opa_value = JSONBoolean(value);
-  }
+  void SetBoolean(bool value) { opa_value = JSONBoolean(value); }
 
-  void SetString(char const* value) {
-    opa_value = JSONString(value);
-  }
+  void SetString(char const* value) { opa_value = JSONString(value); }
 
-  void SetNumberFromString(char const* value) {
-    opa_value = JSONNumber(current::FromString<double>(value));
-  }
+  void SetNumberFromString(char const* value) { opa_value = JSONNumber(current::FromString<double>(value)); }
 
   value_t GetByKey(char const* key) {
     return Exists<JSONObject>(opa_value) ? Value<JSONObject>(opa_value)[key] : value_t();
@@ -96,9 +84,7 @@ inline value_t opa_range(value_t const& a, value_t const& b) {
 
 struct result_set_t final {
   std::vector<value_t> result_set;
-  void AddToResultSet(value_t value) {
-    result_set.push_back(std::move(value));
-  }
+  void AddToResultSet(value_t value) { result_set.push_back(std::move(value)); }
   JSONValue pack() const {
     if (result_set.empty()) {
       return JSONNull();

--- a/scripts/ir2cpp_runner_before.cc
+++ b/scripts/ir2cpp_runner_before.cc
@@ -136,5 +136,3 @@ struct result_set_t final {
     }
   }
 };
-
-using locals_t = std::map<size_t, value_t>;

--- a/scripts/ir2cpp_runner_before.cc
+++ b/scripts/ir2cpp_runner_before.cc
@@ -18,6 +18,7 @@ class OPAValue final {
 
  public:
   OPAValue() : opa_value(JSONNull()) {}
+  OPAValue(std::nullptr_t) : opa_value(JSONNull()) {}
   OPAValue(JSONValue opa_value) : opa_value(std::move(opa_value)) {}
   OPAValue(OPAString const& s) {
     if (Exists(s)) {
@@ -34,6 +35,11 @@ class OPAValue final {
       opa_value = JSONBoolean(Value(b));
     }
   }
+
+  OPAValue(std::string s) : opa_value(JSONString(std::move(s))) {}
+  OPAValue(int i) : opa_value(JSONNumber(i)) {}
+  OPAValue(double d) : opa_value(JSONNumber(d)) {}
+  OPAValue(bool b) : opa_value(JSONBoolean(b)) {}
 
   void DoResetToUndefined() { opa_value = JSONNull(); }
   bool DoIsUndefined() const { return Exists<JSONNull>(opa_value); }
@@ -69,8 +75,8 @@ inline bool IsUndefined(OPAValue const& value) { return value.DoIsUndefined(); }
 inline bool IsUndefined(Optional<std::string> const& value) { return Exists(value); }
 
 inline bool IsStringEqualTo(OPAValue const& value, char const* s) { return value.DoIsStringEqualTo(s); }
-
 inline bool IsStringEqualTo(OPAString const& value, char const* s) { return Exists(value) && Value(value) == s; }
+inline bool IsStringEqualTo(std::string const& value, char const* s) { return value == s; }
 
 // TODO(dkorolev): Should return a custom type that can be assigned to a string "variable" too!
 inline OPAValue Undefined() {
@@ -98,26 +104,26 @@ inline OPANumber NumberFromString(char const* s) { return OPANumber(current::Fro
 
 inline OPAValue opa_plus(OPAValue const& a, OPAValue const& b) {
   if (Exists<JSONNumber>(a.opa_value) && Exists<JSONNumber>(b.opa_value)) {
-    return OPAValue(JSONNumber(Value<JSONNumber>(a.opa_value).number + Value<JSONNumber>(b.opa_value).number));
+    return Value<JSONNumber>(a.opa_value).number + Value<JSONNumber>(b.opa_value).number;
   } else {
-    return OPAValue();
+    return nullptr;
   }
 }
 
 inline OPAValue opa_minus(OPAValue const& a, OPAValue const& b) {
   // TODO(dkorolev): Only work on numbers!
   if (Exists<JSONNumber>(a.opa_value) && Exists<JSONNumber>(b.opa_value)) {
-    return OPAValue(JSONNumber(Value<JSONNumber>(a.opa_value).number - Value<JSONNumber>(b.opa_value).number));
+    return Value<JSONNumber>(a.opa_value).number - Value<JSONNumber>(b.opa_value).number;
   } else {
-    return OPAValue();
+    return nullptr;
   }
 }
 
 inline OPAValue opa_mul(OPAValue const& a, OPAValue const& b) {
   if (Exists<JSONNumber>(a.opa_value) && Exists<JSONNumber>(b.opa_value)) {
-    return OPAValue(JSONNumber(Value<JSONNumber>(a.opa_value).number * Value<JSONNumber>(b.opa_value).number));
+    return Value<JSONNumber>(a.opa_value).number * Value<JSONNumber>(b.opa_value).number;
   } else {
-    return OPAValue();
+    return nullptr;
   }
 }
 


### PR DESCRIPTION
Hi @mzhurovich,

Here's the first functional strongly typed version. It heavily leverages `template`-s, `decltype` and `auto`. In fact, if the same Rego function is be called from multiple places with different argument types, the transpiled C++ code would generate several functions, one for each set of input argument types, each optimized accordingly.

I had to get rid of the `locals[]` array, as all its elements are of the same, most generic, umbrella type. Now, each "local variable" is declared independently. Here's the resulting code for `result = input.a + input.b`:

```
template <typename T1, typename T2>
decltype(auto) function_0(T1&& p1, T2&& p2) {
  OPAValue retval;
  OPAValue x1;
  decltype(rego_string_a::GetValueByKeyFrom(std::forward<T1>(p1))) x2;
  decltype(x2) x3;
  decltype(rego_string_b::GetValueByKeyFrom(std::forward<T1>(p1))) x4;
  decltype(x4) x5;
  decltype(opa_plus(x3, x5)) x6;
  decltype(x6) x7;
  decltype(x1) x8;
  x1 = Undefined();
  x2 = rego_string_a::GetValueByKeyFrom(std::forward<T1>(p1));
  x3 = x2;
  x4 = rego_string_b::GetValueByKeyFrom(std::forward<T1>(p1));
  x5 = x4;
  x6 = opa_plus(x3, x5);
  x7 = x6;
  if (IsUndefined(x1)) {
    x1 = x7;
  }
  if (!IsUndefined(x1)) {
    x8 = x1;
  }
  retval = x8;
  return retval;
}
template <typename T_INPUT, typename T_DATA>
OPAResult policy(T_INPUT&& input, T_DATA&& data) {
  OPAResult result;
  decltype(function_0(std::declval<T_INPUT>(), std::declval<T_DATA>())) x1;
  decltype(x1) x2;
  OPAValue x3;
  x1 = function_0(input, data);
  x2 = x1;
  x3 = Object();
  SetValueForKey(x3, "result", x2);
  result.AddToResultSet(x3);
  return result;
}
```

(The above autogenerated code follows Rego's IR one-to-one, but I believe the C++ compiler would take care of unnecessary assignments. I hope to get to the disassembly part one day, but, for now, there's certainly bigger fish to fry.)

This gets us to the point where a custom type can be used. Specifically, struct `Input`, defined as:

```
struct Input {
  int a;
  int b;
};
```

Can be passed to the same `policy()` function, and:

* The type-aware, optimized code will be generated, and
* If any field can not be found, or has the wrong type, it will be a compilation error.

I've tested the above manually, including on a more convoluted [example](https://github.com/C5T/jsopa/blob/main/tests/indirect_call/p3.rego), where the input is:

```
struct Input {
  string f;  // Can be "add", "mul", or "range".
  int a;
  int b;
};
```

And it worked like a charm (here's a `.gitignore`-d [tests/indirect_call/p3.rego.stage3.cpp](https://gist.github.com/dkorolev/a0915308fbcc615b49e943b1f403fa34) generated by `./scripts/gen_all_cpp.sh`).

Ideally, the above should play well with the existing Rego's type checking mechanisms; i.e. parse the schema JSON-s automatically as well. There are only so many hours in the day though, gotta prioritize accordingly.

---

CC @joaopaulog: The above should play well with gRPC (i.e., with `.proto`-typed messages). My vision is to build a pipeline that treats `.rego` policies a lot like `.proto` gRPC service definitions:

* The `.rego` file is available for the build. (Maybe in the same repo or in a submodule, or maybe brought by a build script).
* One build step is to is automatically convert this `.rego` file into a piece of code (could be a `.class` for JVM).
* The user code can then invoke OPA policies natively.

And these native policy invocations can use local data structures of the language in which the user code is developed. No JSON marshaling and no network communication.

In fact, if the language used is flexible enough (such as C++), those internal data structures may even implement lazy data loading on the fly, behind the scenes, which the author of the OPA/rego policy would be blissfully unaware of!

That's down the road though; gRPC-first is my plan for now, as in the real project we are using OPA for we have already converged to gRPC as the source of truth of the schema for the data providers for our AuthZ policies.

---

CC @anderseknert, we're at the point where lower-level IR questions emerge. The major ones where you guys may have the answers in your warmed up brain cache are:

1. The "return statement" from the IR: does it terminate the block, or the function, or none at all, just initializing a (temporary) "return variable"? I'm leaning towards the former (that's what [the documentation](https://www.openpolicyagent.org/docs/latest/ir/#blocks) says), but then why is the index of the local to be returned part of the IR function signature? And if it is the latter, can this "return variable" be overwritten later? If yes, does the "return type" has to be the same? Intuitively, it's quite a tricky case, and I wonder what your thoughts on it are, as you're clearly ahead of these experiments ;-)

2. Is there a good summary of the rules that are `break`-ing the block? For example the 

3. Is it by design that all the constants in the IR are strings? I'd expect the numbers to be numbers, but for now it looks like we have to be manually parsing them from strings.

And the question of testing stands tall. We have quite a narrow subset subset of the IR now (~75% of the "opcodes", ~10% of builtin functions, and we took some shortcuts such as not differentiating between `null` and `undefined`). I would imagine you guys have plenty of large-scale tests to cover most of Rego's functionality. Shall we join forces here, ideally, in a high-performance setting, if some of your existing customers is dying to see Rego evaluating their policies faster, and on fewer boxes? I'd be motivated to look into this, as it's exactly the problem we'll be facing around Q4/Q1 in our own end user AuthZ use case.

Thanks,
Dima